### PR TITLE
Fix to avoid circular reference

### DIFF
--- a/shooting-game/SpaceShip.swift
+++ b/shooting-game/SpaceShip.swift
@@ -9,7 +9,7 @@
 import Foundation
 import SpriteKit
 
-protocol SpaceShipDelegate {
+protocol SpaceShipDelegate: class {
   func displayHeart(hearts: [SKSpriteNode])
   func addBullet()
 }
@@ -49,7 +49,7 @@ class SpaceShip: SKSpriteNode {
   var moveSpeed: CGFloat
   var viewFrame: CGRect
   var hearts: [SKSpriteNode] = []
-  var delegate: SpaceShipDelegate?
+  weak var delegate: SpaceShipDelegate?
   
   var timerForPowerItem: Timer?
   var powerUpTime: Float = 5.0 {


### PR DESCRIPTION
## 概要
- delegate変数を弱参照で宣言していなかったため、weakキーワードを追加して循環参照を回避