### PR TITLE
Fix spaceship move

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -2,8 +2,9 @@
 
 # 無効にするルール
 disabled_rules:
-  - force_cast
-  - force_try
+  - force_cast //使っていいものに対して使うため
+  - force_try //上同
+  - implicitly_unwrapped_optional //上同
 
 # defaultルール以外にopt-inから採用するルール
 opt_in_rules:
@@ -27,7 +28,7 @@ opt_in_rules:
   - function_default_parameter_at_end
   - identical_operands
   - implicit_return
-  - implicitly_unwrapped_optional
+  #- implicitly_unwrapped_optional
   - joined_default_parameter
   - last_where
   - legacy_random

--- a/shooting-game/GameScene.swift
+++ b/shooting-game/GameScene.swift
@@ -33,6 +33,7 @@ class GameScene: SKScene {
 
     var spaceship: SpaceShip?
     var scoreLabel: SKLabelNode?
+    var touchPosition: CGPoint?
 
     let planets = ["asteroid1", "asteroid2", "asteroid3"]
     let itemTypes: [PowerItem.ItemType] = [.speed, .stone]
@@ -72,6 +73,7 @@ class GameScene: SKScene {
     }
 
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        touchPosition = convertPoint(fromView: touches.first!.location(in: view))
         addBullet()
         bulletTimer?.invalidate()
         bulletTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] _ in
@@ -80,17 +82,22 @@ class GameScene: SKScene {
     }
 
     override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
-        guard let spaceship = spaceship,
-            let touch = touches.first else {
-            return
-        }
-        let movement = convertPoint(fromView: touch.location(in: view)) - spaceship.position
-        spaceship.position += movement * spaceship.moveSpeed / 5
+        touchPosition = convertPoint(fromView: touches.first!.location(in: view))
     }
 
     override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
         if isPaused { endGame() }
         bulletTimer?.invalidate()
+        touchPosition = nil
+    }
+
+    override func update(_ currentTime: TimeInterval) {
+        guard let spaceship = spaceship,
+            let position = touchPosition else {
+            return
+        }
+        let movement = position - spaceship.position
+        spaceship.position += movement * spaceship.moveSpeed / 5
     }
 
     func gameOver() {

--- a/shooting-game/GameScene.swift
+++ b/shooting-game/GameScene.swift
@@ -31,7 +31,7 @@ class GameScene: SKScene {
         }
     }
 
-    var spaceship: SpaceShip?
+    var spaceship: SpaceShip!
     var scoreLabel: SKLabelNode?
     var touchPosition: CGPoint?
 
@@ -47,12 +47,11 @@ class GameScene: SKScene {
         physicsWorld.gravity = CGVector(dx: 0, dy: 0)
         physicsWorld.contactDelegate = self
 
-        let ship = SpaceShip(shipType: .blue, moveSpeed: 1, addedViewFrame: frame)
-        ship.delegate = self
-        ship.setHitPoint(hitPoint: 5)
-        ship.setPhysicsBody(categoryBitMask: spaceshipCategory, contactTestBitMask: asteroidCategory + powerItemCategory)
-        addChild(ship)
-        spaceship = ship
+        spaceship = SpaceShip(shipType: .blue, moveSpeed: 1, addedViewFrame: frame)
+        spaceship.delegate = self
+        spaceship.setHitPoint(hitPoint: 5)
+        spaceship.setPhysicsBody(categoryBitMask: spaceshipCategory, contactTestBitMask: asteroidCategory + powerItemCategory)
+        addChild(spaceship)
 
         asteroidTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true ) { _ in
             self.addAsteroid()
@@ -92,8 +91,7 @@ class GameScene: SKScene {
     }
 
     override func update(_ currentTime: TimeInterval) {
-        guard let spaceship = spaceship,
-            let position = touchPosition else {
+        guard let position = touchPosition else {
             return
         }
         let movement = position - spaceship.position
@@ -164,9 +162,6 @@ extension GameScene: SpaceShipDelegate {
     }
 
     func addBullet() {
-        guard let spaceship = spaceship else {
-            return
-        }
         let bullet = Bullet(bulletType: .missile, position: spaceship.position)
         bullet.setPhysicsBody(categoryBitMask: missileCategory, contactTestBitMask: asteroidCategory + powerItemCategory)
         addChild(bullet)
@@ -190,8 +185,7 @@ extension GameScene: SKPhysicsContactDelegate {
             target = contact.bodyA
         }
 
-        guard let spaceship = spaceship,
-            let effectingNode = effecting.node,
+        guard let effectingNode = effecting.node,
             let targetNode = target.node,
             let explosion = SKEmitterNode(fileNamed: "Explosion") else { return }
         explosion.position = effectingNode.position

--- a/shooting-game/GameScene.swift
+++ b/shooting-game/GameScene.swift
@@ -94,8 +94,7 @@ class GameScene: SKScene {
         guard let position = touchPosition else {
             return
         }
-        let movement = position - spaceship.position
-        spaceship.position += movement * spaceship.moveSpeed / 5
+        spaceship.moveToPosition(touchPosition: position)
     }
 
     func gameOver() {

--- a/shooting-game/SpaceShip.swift
+++ b/shooting-game/SpaceShip.swift
@@ -101,6 +101,11 @@ class SpaceShip: SKSpriteNode {
         physicsBody?.collisionBitMask = 0
     }
 
+    func moveToPosition(touchPosition position: CGPoint) {
+        let movement = position - self.position
+        self.position += movement * moveSpeed / 5
+    }
+
     func powerUp(itemType: PowerItem.ItemType) {
         state.shipPowerUp(itemType: itemType)
         switch itemType {


### PR DESCRIPTION
## 概要
- スペースシップの移動処理を`touchMove`に書いていたものを`update`へと移した
  - a7d90d6
- `spaceShip`変数は、`didMove`で初期化されている場合必ず`nil`にはならないため暗黙的アンラップ変数にした
  - 7ec1c81
- 移動処理を`SpaceShipClass`に移譲する実装にした
  - a752648
## 備考
- fixes #24